### PR TITLE
♻️ QA/Header Component 25번 해결

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -216,7 +216,7 @@ const HeaderContainer = styled.header`
   width: 100%;
   height: 110px;
   top: 0;
-  z-index: 99;
+  z-index: 9;
   transition: all 0.3s ease-in-out;
 
   ${props => {


### PR DESCRIPTION
- 원인 : Z-INDEX 이슈로 인하여 Header의 Z-INDEX가 모달의 Z-INDEX보다 커서 발생한 이슈
- 해결 : Header의 Z-INDEX 값 감소